### PR TITLE
Add support for reusing the same PR comment for badges/details

### DIFF
--- a/.github/workflows/os-matrix.json
+++ b/.github/workflows/os-matrix.json
@@ -1,0 +1,1 @@
+["ubuntu-latest", "windows-latest", "macOS-latest"]

--- a/src/Demo/Attributes.cs
+++ b/src/Demo/Attributes.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Demo;
+
+public class PlatformFactAttribute : FactAttribute
+{
+    public PlatformFactAttribute(PlatformID platform)
+    {
+        if (Environment.OSVersion.Platform != platform)
+            Skip = $"Test only runs on {platform}";
+    }
+}

--- a/src/Demo/Tests.cs
+++ b/src/Demo/Tests.cs
@@ -38,6 +38,12 @@ public class Tests(ITestOutputHelper output)
         runner();
     }
 
+    [PlatformFact(PlatformID.Win32NT)]
+    public void WindowsOnlyTest() => output.WriteLine("This test runs only on Windows");
+
+    [PlatformFact(PlatformID.Unix)]
+    public void FailsOnlyOnUnix() => Assert.Fail("Fails on Unix");
+
     void Run() => Unexpected();
 
     void Unexpected() => throw new InvalidOperationException("This should not happen!");

--- a/src/dotnet-trx/Process.cs
+++ b/src/dotnet-trx/Process.cs
@@ -1,27 +1,49 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
+using Spectre.Console.Rendering;
 
 namespace Devlooped;
 
 static class Process
 {
+    public static bool TryExecute(string program, IEnumerable<string> arguments, out string? output)
+        => TryExecuteCore(program, arguments, null, out output);
+
+    public static bool TryExecute(string program, IEnumerable<string> arguments, string input, out string? output)
+        => TryExecuteCore(program, arguments, input, out output);
+
     public static bool TryExecute(string program, string arguments, out string? output)
         => TryExecuteCore(program, arguments, null, out output);
 
     public static bool TryExecute(string program, string arguments, string input, out string? output)
         => TryExecuteCore(program, arguments, input, out output);
 
-    static bool TryExecuteCore(string program, string arguments, string? input, out string? output)
-    {
-        var info = new ProcessStartInfo(program, arguments)
+    static bool TryExecuteCore(string program, IEnumerable<string> arguments, string? input, out string? output)
+        => TryExecuteCore(new ProcessStartInfo(program, arguments)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = input != null
-        };
+        }, input, out output);
 
+    static bool TryExecuteCore(string program, string arguments, string? input, out string? output)
+        => TryExecuteCore(new ProcessStartInfo(program, arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = input != null
+        }, input, out output);
+
+    static bool TryExecuteCore(ProcessStartInfo info, string? input, out string? output)
+    {
         try
         {
+            info.StandardOutputEncoding = Encoding.UTF8;
+            //if (input != null)
+            //    info.StandardInputEncoding = Encoding.UTF8;
+
             var proc = System.Diagnostics.Process.Start(info);
             if (proc == null)
             {

--- a/src/dotnet-trx/TrxCommand.cs
+++ b/src/dotnet-trx/TrxCommand.cs
@@ -238,7 +238,7 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         if (Environment.GetEnvironmentVariable("GITHUB_REF_NAME") is not { } branch ||
             !branch.EndsWith("/merge") ||
             !int.TryParse(branch[..^6], out var pr) ||
-            Environment.GetEnvironmentVariable("GITHUB_REPOSITORY") is not { Length: > 0 } repo || 
+            Environment.GetEnvironmentVariable("GITHUB_REPOSITORY") is not { Length: > 0 } repo ||
             Environment.GetEnvironmentVariable("GITHUB_RUN_ID") is not { Length: > 0 } runId)
             return;
 
@@ -275,7 +275,7 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
             body.IndexOf(Footer) is var end && end != -1 && end > start &&
             // We only append if the run id matches the current run, otherwise we'll just create
             // entirely new body. Means we'll only keep the latest run for the PR to keep the noise down.
-            TrxRunId().Match(body) is { Success: true } match && 
+            TrxRunId().Match(body) is { Success: true } match &&
             match.Groups["id"].Value == runId)
         {
             sb.AppendLine(body[..start].TrimEnd());

--- a/src/dotnet-trx/TrxCommand.cs
+++ b/src/dotnet-trx/TrxCommand.cs
@@ -228,6 +228,10 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         if (summary.Total == 0)
             return;
 
+        if (Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") != "pull_request" ||
+            Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != "true")
+            return;
+
         if (TryExecute("gh", "--version", out var output) && output?.StartsWith("gh version") != true)
             return;
 


### PR DESCRIPTION
This is key when running tests in multiple OSes, since otherwise you end up with one comment for each.

We group the badges at the top, details at bottom, with the OS description to easily determine what ran where. 

The comment is also cleared if a new run is detected, to avoid ever-growing comment from long-running/evolving PRs.

![image](https://github.com/user-attachments/assets/603cedfe-7d17-4aeb-a7c3-ef049f6a335c)
