### PR TITLE
Link badges directly to job run for details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
     name: build-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.os-matrix.outputs.matrix) }}
     steps:
@@ -78,6 +79,8 @@ jobs:
 
       - name: 🧪 show
         if: always()
+        env:
+          GH_JOB_NAME: build-${{ matrix.os }}
         run:  
           dotnet run --no-build --project ./src/dotnet-trx/ --output
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.os-matrix.outputs.matrix) }}
     steps:
+      - name: 🖨️ env
+        if: runner.debug
+        run: printenv
+  
       - name: 🤘 checkout
         uses: actions/checkout@v4
         with: 

--- a/src/dotnet-trx/Process.cs
+++ b/src/dotnet-trx/Process.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
-using Spectre.Console.Rendering;
 
 namespace Devlooped;
 


### PR DESCRIPTION
Makes it far easier to navigate back to the specific job that run the tests

This is not achievable universally and consistently until we get [GITHUB_JOB_ID](https://github.com/orgs/community/discussions/129314) :(

But in the meantime, we do a best-effort to build up the right link. A `GH_JOB_NAME` is provided for matrix-based jobs which otherwise would never match even via API lookup. 