### PR TITLE
Exit code should match success/failure status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: 🧪 show
         if: always()
+        continue-on-error: true
         env:
           GH_JOB_NAME: build-${{ matrix.os }}
         run:  

--- a/src/dotnet-trx/TrxCommand.cs
+++ b/src/dotnet-trx/TrxCommand.cs
@@ -47,6 +47,14 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         [DefaultValue(true)]
         public bool Skipped { get; init; } = true;
 
+        /// <summary>
+        /// Whether to return a -1 exit code on test failures.
+        /// </summary>
+        [Description("Do not return a -1 exit code on test failures")]
+        [CommandOption("--no-exit-code")]
+        [DefaultValue(false)]
+        public bool NoExitCode { get; init; } = false;
+
         [Description("Show version information")]
         [CommandOption("--version")]
         public bool? Version { get; init; }
@@ -217,7 +225,7 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
             }
         }
 
-        return 0;
+        return settings.NoExitCode || failed == 0 ? 0 : -1;
     }
 
     static void MarkupSummary(Summary summary)


### PR DESCRIPTION
This makes it easier to use it to stop CI steps, without having to re-calculate overall test results status.

In CI, `continue-on-error` can be set to `true` if trx is run as a separate step.

The backwards compatibility option `--no-exit-code` can be used to ignore failures and always return success/0.

This also means you can safely chain calls to `dotnet test` without losing the status code result, such as:

`dotnet test -l trx || trx`

this would result in a trx report only if dotnet-test failed, and preserve the failure after trx issues the report.