### PR TITLE
Auto-document CLI options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,16 +32,7 @@ And view results in an automatic pull request comment like:
 > NOTE: this behavior is triggered by the presence of the `GITHUB_REF_NAME` and `CI` environment variables.
 
 ```shell
-USAGE:
-    trx [OPTIONS]
-
-OPTIONS:
-                       DEFAULT
-    -h, --help                    Prints help information
-    -p, --path                    Optional base directory for *.trx files discovery. Defaults to current directory
-    -o, --output       False      Include test output
-    -r, --recursive    True       Recursively search for *.trx files
-        --version                 Show version information
+<!-- include src/dotnet-trx/help.txt -->
 ```
 
 Install:

--- a/src/dotnet-trx/dotnet-trx.csproj
+++ b/src/dotnet-trx/dotnet-trx.csproj
@@ -35,4 +35,8 @@
     <ProjectProperty Include="PackageProjectUrl" />
   </ItemGroup>
 
+  <Target Name="RenderHelp" AfterTargets="Build">
+    <Exec Command="dotnet run --no-build -- -? &gt; help.txt" EnvironmentVariables="NO_COLOR=true" />
+  </Target>
+
 </Project>

--- a/src/dotnet-trx/help.txt
+++ b/src/dotnet-trx/help.txt
@@ -1,0 +1,16 @@
+USAGE:
+    trx [OPTIONS]
+
+OPTIONS:
+                          DEFAULT                                               
+    -h, --help                       Prints help information                    
+    -p, --path                       Optional base directory for *.trx files    
+                                     discovery. Defaults to current directory   
+    -o, --output                     Include test output                        
+    -r, --recursive       [1mTrue[0m       Recursively search for *.trx files         
+        --skipped         [1mTrue[0m       Include skipped tests                      
+        --no-exit-code               Do not return a -1 exit code on test       
+                                     failures                                   
+        --version                    Show version information                   
+        --gh-comment      [1mTrue[0m       Report as GitHub PR comment                
+        --gh-summary      [1mTrue[0m       Report as GitHub step summary              


### PR DESCRIPTION
Instead of trying to keep the section on usage updated, automate it instead:

* Build emits a new help.md as needed
* These changes will be pushed as usual
* Markdown include from main readme to help.md will resolve it automatically
* Nugetizer already resolves includes
* markdown includes workflow takes care of keeping project readme updated