### PR TITLE
Restore formatting and links for errors, escape per line

### DIFF
--- a/src/dotnet-trx/TrxCommand.cs
+++ b/src/dotnet-trx/TrxCommand.cs
@@ -414,12 +414,12 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         else
             details.AppendLine("csharp");
 
-        foreach (var line in lines)
+        foreach (var line in lines.Select(x => x.EscapeMarkup()))
         {
             var match = ParseFile().Match(line);
             if (!match.Success)
             {
-                cli.AppendLine(line.EscapeMarkup());
+                cli.AppendLine(line);
                 details.AppendLineIndented(line, "> ");
                 continue;
             }
@@ -445,7 +445,7 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         var error = new Panel(
             $"""
             [red]{message.EscapeMarkup()}[/]
-            [dim]{cli.ToString().EscapeMarkup()}[/]
+            [dim]{cli}[/]
             """);
         error.Padding = new Padding(5, 0, 0, 0);
         error.Border = BoxBorder.None;


### PR DESCRIPTION
The previous fix disabled formatting entirely, this restores that but fixes the per-line styling errors (i.e. string containing `[T]`) before adding the links.