### PR TITLE
Don't fail for non-executed tests which have no `duration` value

### DIFF
--- a/src/Demo/Tests.cs
+++ b/src/Demo/Tests.cs
@@ -38,6 +38,9 @@ public class Tests(ITestOutputHelper output)
         runner();
     }
 
+    [Fact(Skip = "Ignored")]
+    public void Ignored() { }
+
     [PlatformFact(PlatformID.Win32NT)]
     public void WindowsOnlyTest() => output.WriteLine("This test runs only on Windows");
 

--- a/src/dotnet-trx/TrxCommand.cs
+++ b/src/dotnet-trx/TrxCommand.cs
@@ -138,7 +138,7 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         foreach (var result in results)
         {
             var test = result.Attribute("testName")!.Value.EscapeMarkup();
-            var elapsed = TimeSpan.Parse(result.Attribute("duration")!.Value);
+            var elapsed = TimeSpan.Parse(result.Attribute("duration")?.Value ?? "0");
             var output = settings.Output ? result.CssSelectElement("StdOut")?.Value : default;
 
             switch (result.Attribute("outcome")?.Value)


### PR DESCRIPTION
Fixes #57 and #65