### PR TITLE
Quieter output by default

### DIFF
--- a/src/dotnet-trx/Program.cs
+++ b/src/dotnet-trx/Program.cs
@@ -30,7 +30,7 @@ app.Configure(config =>
         config.Settings.HelpProviderStyles = null;
 });
 
-if (args.Contains("--version") || args.Contains("-v"))
+if (args.Contains("--version"))
 {
     AnsiConsole.MarkupLine($"{ThisAssembly.Project.ToolCommandName} version [lime]{ThisAssembly.Project.Version}[/] ({ThisAssembly.Project.BuildDate})");
     AnsiConsole.MarkupLine($"[link]{ThisAssembly.Git.Url}/releases/tag/{ThisAssembly.Project.BuildRef}[/]");

--- a/src/dotnet-trx/help.md
+++ b/src/dotnet-trx/help.md
@@ -3,16 +3,31 @@ USAGE:
     trx [OPTIONS]
 
 OPTIONS:
-                          DEFAULT                                               
-    -h, --help                       Prints help information                    
-    -v, --version                    Prints version information                 
-    -p, --path                       Optional base directory for *.trx files    
-                                     discovery. Defaults to current directory   
-    -o, --output                     Include test output                        
-    -r, --recursive       True       Recursively search for *.trx files         
-        --skipped         True       Include skipped tests                      
-        --no-exit-code               Do not return a -1 exit code on test       
-                                     failures                                   
-        --gh-comment      True       Report as GitHub PR comment                
-        --gh-summary      True       Report as GitHub step summary              
+                                              DEFAULT                           
+    -h, --help                                           Prints help information
+    -v, --version                                        Prints version         
+                                                         information            
+    -p, --path                                           Optional base directory
+                                                         for *.trx files        
+                                                         discovery. Defaults to 
+                                                         current directory      
+    -o, --output                                         Include test output    
+    -r, --recursive                           True       Recursively search for 
+                                                         *.trx files            
+    -v, --verbosity <QUIET|NORMAL|VERBOSE>    Quiet      Output display         
+                                                         verbosity:             
+                                                         - quiet: only failed   
+                                                         tests are displayed    
+                                                         - normal: failed and   
+                                                         skipped tests are      
+                                                         displayed              
+                                                         - verbose: failed,     
+                                                         skipped and passed     
+                                                         tests are displayed    
+        --no-exit-code                                   Do not return a -1 exit
+                                                         code on test failures  
+        --gh-comment                          True       Report as GitHub PR    
+                                                         comment                
+        --gh-summary                          True       Report as GitHub step  
+                                                         summary                
 ```


### PR DESCRIPTION
Most projects will have a large number of tests. In such cases, running the report will tipically be necessary in order to know if something is failing. Even skipped tests might be quite common if they are skipped depending on the current platform (for xplat matrix runs in CI, for example).

As such, the default should be something that is sensible, rather than verbose.

We introduce the new `-v|--verbosity` switch with the following options:
- quiet: only failed tests are displayed
- normal: failed and skipped tests are displayed
- verbose: failed, skipped and passed tests are displayed

The default is `quiet`. We hide the older Skipped and implement it in terms of the new property.

This also means we must remove the `-v` alias for `--version`, since it would be ambiguous.

Reverts #58
Fixes #59