### PR TITLE
When writing GH comment summary, include error message

### DIFF
--- a/src/dotnet-trx/TrxCommand.cs
+++ b/src/dotnet-trx/TrxCommand.cs
@@ -265,6 +265,7 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
             {
                 // Send workflow commands for each failure to be annotated in GH CI
                 // TODO: somehow the notice does not end up pointing to the right file/line
+                // TODO: we should do newline replacement with "%0A" here too
                 //foreach (var failure in failures)
                 //    WriteLine($"::error file={failure.File},line={failure.Line},title={failure.Title}::{failure.Message}");
             }
@@ -460,6 +461,9 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
         else
             details.AppendLine("csharp");
 
+        // First line should be the actual error message.
+        details.AppendLineIndented(message.ReplaceLineEndings(), "> ");
+
         foreach (var line in lines.Select(x => x.EscapeMarkup()))
         {
             var match = ParseFile().Match(line);
@@ -479,8 +483,8 @@ public partial class TrxCommand : Command<TrxCommand.TrxSettings>
             // NOTE: we replace whichever was last, since we want the annotation on the 
             // last one with a filename, which will be the test itself (see previous skip from last found).
             failed = new Failed(testName,
-                message.ReplaceLineEndings().Replace(Environment.NewLine, "%0A"),
-                stackTrace.ReplaceLineEndings().Replace(Environment.NewLine, "%0A"),
+                message.ReplaceLineEndings(),
+                stackTrace.ReplaceLineEndings(),
                 relative, int.Parse(pos));
 
             cli.AppendLine(line.Replace(file, $"[link={file}][steelblue1_1]{relative}[/][/]"));


### PR DESCRIPTION
We were not including the actual exception message as the first line in the GH comment report.

<img width="835" height="493" alt="image" src="https://github.com/user-attachments/assets/cd059a17-4b1f-4a86-98e9-322821abc297" />

Fixes #85